### PR TITLE
Updating the mainfests with minimal rbac changes

### DIFF
--- a/k8s-manifests/ci/hce-cluster-scope.yaml
+++ b/k8s-manifests/ci/hce-cluster-scope.yaml
@@ -530,7 +530,7 @@ spec:
         - name: regcred
       initContainers:
         - name: wait-for-mongodb
-          image: litmuschaos/curl:latest
+          image: litmuschaos/curl:2.6.0
           command: ["/bin/sh", "-c"]
           args:
             [
@@ -674,7 +674,7 @@ spec:
         - name: regcred
       initContainers:
         - name: wait-for-mongodb
-          image: litmuschaos/curl:latest
+          image: litmuschaos/curl:2.6.0
           command: ["/bin/sh", "-c"]
           args:
             [
@@ -812,7 +812,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: wait-for-mongodb
-          image: litmuschaos/curl:latest
+          image: litmuschaos/curl:2.6.0
           command: ["/bin/sh", "-c"]
           args:
             [

--- a/k8s-manifests/ci/hce-cluster-scope.yaml
+++ b/k8s-manifests/ci/hce-cluster-scope.yaml
@@ -198,6 +198,11 @@ rules:
   resources: [rollouts]
   verbs: [list, get]
 
+  # performs CRUD operations on the network policies
+- apiGroups: ["networking.k8s.io"]
+  resources: ["networkpolicies"]
+  verbs: ["create","delete","list","get"]
+
   # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
 - apiGroups: [litmuschaos.io]
   resources: [chaosengines, chaosexperiments, chaosresults]

--- a/k8s-manifests/ci/hce-cluster-scope.yaml
+++ b/k8s-manifests/ci/hce-cluster-scope.yaml
@@ -20,7 +20,7 @@ rules:
   resources: [workflows, workflows/finalizers]
   verbs: [get, list, watch, update, patch, delete, create]
 - apiGroups: [argoproj.io]
-  resources: [workflowtemplates, workflowtemplates/finalizers, clusterworkflowtemplates, clusterworkflowtemplates/finalizers, workflowtasksets]
+  resources: [workflowtemplates, workflowtemplates/finalizers, clusterworkflowtemplates, clusterworkflowtemplates/finalizers,workflowtasksets]
   verbs: [get, list, watch]
 - apiGroups: [""]
   resources: [serviceaccounts]
@@ -79,8 +79,15 @@ rules:
     resources: [rollouts]
     verbs: [get, list]
   - apiGroups: [""]
-    resources: [pods, configmaps, events, services]
+    resources: [pods]
     verbs: [get, create, update, patch, delete, list, watch, deletecollection]
+  - apiGroups: [""]
+    resources: [configmaps, events, secrets]
+    verbs: [get, create, update, patch, list, watch]
+# Required for deletion of the services of predefined workflow
+  - apiGroups: [""]
+    resources: [services]
+    verbs: [get, create, update, patch, list, watch, delete]
   - apiGroups: [litmuschaos.io]
     resources: [chaosengines, chaosexperiments, chaosresults]
     verbs: [get, create, update, patch, delete, list, watch, deletecollection]
@@ -127,9 +134,11 @@ rules:
 
   # for creating and monitoring the chaos-runner pods
 - apiGroups: [""]
-  resources: [pods,events]
+  resources: [pods]
   verbs: [create, delete, get, list, patch, update, deletecollection]
-
+- apiGroups: [""]
+  resources: [events]
+  verbs: [create, get, list, patch, update]
   # for fetching configmaps and secrets to inject into chaos-runner pod (if specified)
 - apiGroups: [""]
   resources: [secrets, configmaps]
@@ -149,24 +158,6 @@ rules:
   # Permissions needed for creation and discovery of chaos experiments
   # ********************************************************************
 
-  # The helper pods are created by experiment to perform the actual chaos injection ...
-  # ... for a period of chaos duration
-
-  # for creating and deleting the helper or target app pod and events by experiment
-- apiGroups: [""]
-  resources: [pods]
-  verbs: [create, delete, deletecollection]
-
-  # for creating and monitoring the events for chaos operations
-- apiGroups: [""]
-  resources: [events]
-  verbs: [create, delete, get, list, patch, update, deletecollection]
-
-  # for monitoring the helper and target app pod
-- apiGroups: [""]
-  resources: [pods]
-  verbs: [get, list, patch, update]
-
   # for creating and managing to execute comands inside target container
 - apiGroups: [""]
   resources: [pods/exec, pods/eviction, replicationcontrollers]
@@ -180,12 +171,12 @@ rules:
   # for creating and monitoring liveness services or monitoring target app services during chaos injection
 - apiGroups: [""]
   resources: [services]
-  verbs: [create, delete, get, list, delete, deletecollection]
+  verbs: [create, get, list]
 
   # for checking the app parent resources as deployments or sts and are eligible chaos candidates
 - apiGroups: [apps]
   resources: [deployments, statefulsets]
-  verbs: [list, get, patch, update, create, delete]
+  verbs: [list, get, patch, update, create]
 
   # for checking the app parent resources as replicasets and are eligible chaos candidates
 - apiGroups: [apps]
@@ -195,7 +186,7 @@ rules:
   # for checking the app parent resources as deamonsets and are eligible chaos candidates
 - apiGroups: [apps]
   resources: [daemonsets]
-  verbs: [list, get, delete]
+  verbs: [list, get]
 
   # for checking (openshift) app parent resources if they are eligible chaos candidates
 - apiGroups: [apps.openshift.io]
@@ -239,18 +230,25 @@ metadata:
 rules:
   # for managing the pods created by workflow controller to implement individual steps in the workflow
   - apiGroups: [""]
-    resources: [pods, services, namespaces]
+    resources: [pods]
     verbs: [create, get, watch, patch, delete, list]
+
+  - apiGroups: [""]
+    resources: [services, namespaces]
+    verbs: [create, get, watch, patch, list]
 
   # for tracking & getting logs of the pods created by workflow controller to implement individual steps in the workflow
   - apiGroups: [""]
-    resources: [pods/log, secrets, configmaps]
-    verbs: [get, watch, create, delete, patch]
+    resources: [pods/log]
+    verbs: [get, watch, create, patch, delete]
 
+  - apiGroups: [""]
+    resources: [secrets, configmaps]
+    verbs: [get, watch,patch]
   # for creation & deletion of application in predefined workflows
   - apiGroups: [apps]
     resources: [deployments, statefulsets]
-    verbs: [get, watch, patch, create, delete]
+    verbs: [get, watch, patch, create]
 
   # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
   - apiGroups: [litmuschaos.io]
@@ -294,8 +292,11 @@ rules:
   resources: [deploymentconfigs]
   verbs: [get, list]
 - apiGroups: [apps]
+  resources: [deployments]
+  verbs: [delete]
+- apiGroups: [apps]
   resources: [deployments, daemonsets, replicasets, statefulsets]
-  verbs: [get, list, delete]
+  verbs: [get, list,]
 - apiGroups: [argoproj.io]
   resources: [workflows, workflows/finalizers, workflowtemplates, workflowtemplates/finalizers, cronworkflows, cronworkflows/finalizers, clusterworkflowtemplates, clusterworkflowtemplates/finalizers, rollouts]
   verbs: [get, list, create, delete, update, watch]
@@ -536,7 +537,7 @@ spec:
               cpu: "25m"
               ephemeral-storage: "100Mi"
             limits:
-              memory: "200Mi" 
+              memory: "200Mi"
               cpu: "75m"
               ephemeral-storage: "200Mi"
       containers:
@@ -555,6 +556,11 @@ spec:
           ports:
             - containerPort: 8080
           imagePullPolicy: Always
+          securityContext:
+            runAsUser: 2000
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
           resources:
             requests:
               memory: "300Mi"
@@ -616,7 +622,7 @@ spec:
               cpu: "25m"
               ephemeral-storage: "500Mi"
             limits:
-              memory: "300Mi" 
+              memory: "300Mi"
               cpu: "25m"
               ephemeral-storage: "1Gi"
           volumeMounts:
@@ -796,12 +802,12 @@ spec:
       labels:
         component: litmusportal-auth-server
     spec:
-      automountServiceAccountToken: false
       imagePullSecrets:
         - name: regcred
+      automountServiceAccountToken: false
       initContainers:
         - name: wait-for-mongodb
-          image: litmuschaos/curl:2.6.0
+          image: litmuschaos/curl:latest
           command: ["/bin/sh", "-c"]
           args:
             [

--- a/k8s-manifests/ci/hce-namespace.yaml
+++ b/k8s-manifests/ci/hce-namespace.yaml
@@ -253,6 +253,11 @@ rules:
     resources: [rollouts]
     verbs: [list, get]
 
+  # performs CRUD operations on the network policies
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["create","delete","list","get"]
+    
     # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
   - apiGroups: [litmuschaos.io]
     resources: [chaosengines, chaosexperiments, chaosresults]

--- a/k8s-manifests/ci/hce-namespace.yaml
+++ b/k8s-manifests/ci/hce-namespace.yaml
@@ -257,7 +257,7 @@ rules:
   - apiGroups: ["networking.k8s.io"]
     resources: ["networkpolicies"]
     verbs: ["create","delete","list","get"]
-    
+
     # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
   - apiGroups: [litmuschaos.io]
     resources: [chaosengines, chaosexperiments, chaosresults]
@@ -516,7 +516,7 @@ spec:
         - name: regcred
       initContainers:
         - name: wait-for-mongodb
-          image: litmuschaos/curl:latest
+          image: litmuschaos/curl:2.6.0
           command: ["/bin/sh", "-c"]
           args:
             [
@@ -656,7 +656,7 @@ spec:
         - name: regcred
       initContainers:
         - name: wait-for-mongodb
-          image: litmuschaos/curl:latest
+          image: litmuschaos/curl:2.6.0
           command: ["/bin/sh", "-c"]
           args:
             [
@@ -784,7 +784,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: wait-for-mongodb
-          image: litmuschaos/curl:latest
+          image: litmuschaos/curl:2.6.0
           command: ["/bin/sh", "-c"]
           args:
             [

--- a/k8s-manifests/ci/hce-namespace.yaml
+++ b/k8s-manifests/ci/hce-namespace.yaml
@@ -1,5 +1,5 @@
 ### RBAC Manifests
-## If SELF_CLUSTER="true" then these permissions are required to apply 
+## If SELF_CLUSTER="true" then these permissions are required to apply
 ## https://github.com/chaosnative/hce/blob/master/litmus-portal/graphql-server/manifests/namespace/1b_argo_rbac.yaml
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -17,7 +17,7 @@ rules:
     resources: [persistentvolumeclaims]
     verbs: [create, delete]
   - apiGroups: [argoproj.io]
-    resources: [workflows, workflows/finalizers]
+    resources: [workflows, workflows/finalizers,workflowtasksets]
     verbs: [get, list, watch, update, patch, delete, create]
   - apiGroups: [argoproj.io]
     resources: [workflowtemplates, workflowtemplates/finalizers,workflowtasksets]
@@ -81,8 +81,11 @@ rules:
     resources: [rollouts]
     verbs: [get, list]
   - apiGroups: [""]
-    resources: [pods, pods/exec, configmaps, events, services]
+    resources: [pods, pods/exec]
     verbs: [get, create, update, patch, delete, list, watch, deletecollection]
+  - apiGroups: [""]
+    resources: [configmaps, events, services]
+    verbs: [get, create, update, patch, list, watch]
   - apiGroups: [litmuschaos.io]
     resources: [chaosengines, chaosexperiments, chaosresults]
     verbs: [get, create, update, patch, delete, list, watch, deletecollection]
@@ -138,8 +141,11 @@ rules:
     verbs: [get, list]
 
   - apiGroups: [apps]
-    resources: [deployments, daemonsets, replicasets, statefulsets]
-    verbs: [get, list, delete]
+    resources: [deployments]
+    verbs: [delete]
+  - apiGroups: [apps]
+    resources: [deployment, daemonsets, replicasets, statefulsets]
+    verbs: [get, list]
 
   - apiGroups: [argoproj.io]
     resources: [workflows, workflows/finalizers, workflowtemplates, workflowtemplates/finalizers, cronworkflows, cronworkflows/finalizers, rollouts]
@@ -174,8 +180,11 @@ rules:
 
   # for creating and monitoring the chaos-runner pods
   - apiGroups: [""]
-    resources: [pods, events]
+    resources: [pods]
     verbs: [create, delete, get, list, patch, update, deletecollection]
+  - apiGroups: [""]
+    resources: [events]
+    verbs: [create, get, list, patch, update]
 
     # for fetching configmaps and secrets to inject into chaos-runner pod (if specified)
   - apiGroups: [""]
@@ -200,19 +209,9 @@ rules:
     # ... for a period of chaos duration
 
     # for creating and deleting the helper or target app pod and events by experiment
-  - apiGroups: [""]
-    resources: [pods]
-    verbs: [create, delete, deletecollection]
-
     # for creating and monitoring the events for chaos operations
-  - apiGroups: [""]
-    resources: [events]
-    verbs: [create, delete, get, list, patch, update, deletecollection]
 
-    # for monitoring the helper and target app pod
-  - apiGroups: [""]
-    resources: [pods]
-    verbs: [get, list, patch, update]
+
 
     # for creating and managing to execute comands inside target container
   - apiGroups: [""]
@@ -227,12 +226,12 @@ rules:
     # for creating and monitoring liveness services or monitoring target app services during chaos injection
   - apiGroups: [""]
     resources: [services]
-    verbs: [create, delete, get, list, delete, deletecollection]
+    verbs: [create, get, list]
 
     # for checking the app parent resources as deployments or sts and are eligible chaos candidates
   - apiGroups: [apps]
     resources: [deployments, statefulsets]
-    verbs: [list, get, patch, update, create, delete]
+    verbs: [list, get, patch, update, create]
 
     # for checking the app parent resources as replicasets and are eligible chaos candidates
   - apiGroups: [apps]
@@ -242,7 +241,7 @@ rules:
     # for checking the app parent resources as deamonsets and are eligible chaos candidates
   - apiGroups: [apps]
     resources: [daemonsets]
-    verbs: [list, get, delete]
+    verbs: [list, get]
 
     # for checking (openshift) app parent resources if they are eligible chaos candidates
   - apiGroups: [apps.openshift.io]
@@ -286,18 +285,23 @@ metadata:
 rules:
   # for managing the pods created by workflow controller to implement individual steps in the workflow
   - apiGroups: [""]
-    resources: [pods, services]
+    resources: [pods]
     verbs: [create, get, watch, patch, delete, list]
+  - apiGroups: [""]
+    resources: [services]
+    verbs: [create, get, watch, patch, list, delete]
 
   # for tracking & getting logs of the pods created by workflow controller to implement individual steps in the workflow
   - apiGroups: [""]
-    resources: [pods/log, secrets, configmaps]
+    resources: [pods/log]
     verbs: [get, watch, create, delete, patch]
-
+  - apiGroups: [""]
+    resources: [secrets, configmaps]
+    verbs: [get, watch, create, patch]
   # for creation & deletion of application in predefined workflows
   - apiGroups: [apps]
     resources: [deployments, statefulsets]
-    verbs: [get, watch, patch , create, delete]
+    verbs: [get, watch, patch , create]
 
   # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
   - apiGroups: [litmuschaos.io]
@@ -519,7 +523,7 @@ spec:
               cpu: "25m"
               ephemeral-storage: "100Mi"
             limits:
-              memory: "200Mi" 
+              memory: "200Mi"
               cpu: "75m"
               ephemeral-storage: "200Mi"
       containers:
@@ -538,6 +542,11 @@ spec:
           ports:
             - containerPort: 8080
           imagePullPolicy: Always
+          securityContext:
+            runAsUser: 2000
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
           resources:
             requests:
               memory: "300Mi"
@@ -597,7 +606,7 @@ spec:
               cpu: "25m"
               ephemeral-storage: "500Mi"
             limits:
-              memory: "512Mi" 
+              memory: "512Mi"
               cpu: "250m"
               ephemeral-storage: "1Gi"
           volumeMounts:
@@ -642,7 +651,7 @@ spec:
         - name: regcred
       initContainers:
         - name: wait-for-mongodb
-          image: litmuschaos/curl:2.6.0
+          image: litmuschaos/curl:latest
           command: ["/bin/sh", "-c"]
           args:
             [
@@ -654,7 +663,7 @@ spec:
               cpu: "25m"
               ephemeral-storage: "100Mi"
             limits:
-              memory: "200Mi" 
+              memory: "200Mi"
               cpu: "75m"
               ephemeral-storage: "200Mi"
       volumes:
@@ -765,12 +774,12 @@ spec:
       labels:
         component: litmusportal-auth-server
     spec:
-      automountServiceAccountToken: false
       imagePullSecrets:
         - name: regcred
+      automountServiceAccountToken: false
       initContainers:
         - name: wait-for-mongodb
-          image: litmuschaos/curl:2.6.0
+          image: litmuschaos/curl:latest
           command: ["/bin/sh", "-c"]
           args:
             [


### PR DESCRIPTION
Signed-off-by: Adarshkumar14 <adarsh@chaosnative.com>
- Removed `delete` and `deletecollection` permission for the events.
- Removed `delete` permission for sts,ds,rs and deployments(Only subscriber-cr have delete permission to delete deployment.)
- Removed delete permission for the namespace,secrets,configmaps,services.(Only subscriber-cluster-role has permission to delete configmaps and only litmus-cluster-scope-for-litmusportal-server has permission to delete services, It is required to delete services of the predefined workflow.)
- Added `create` ,`delete`, `list`,`get` permission for networkpolicies(Required for pod-network-partition experiment)
- By merging this PR predefined workflows like bank-of-anthos and sock-shop will not work. Users have to manually install these apps.

### Testing:
@Jonsy13 and I had tested it In both cluster-scope Installation and namespace -scope Installation, Control plane and Execution plane components are working as expected, predefined workflow(podato-head) and pod-delete experiment are also working* fine.
*Note:* Need to do the testing for other experiments also.


### Dependency:
Before merging this PR, https://github.com/chaosnative/hce/pull/15 needs to be merged.