### PR TITLE
Updated helmchart for supporting prefixPath in virtual-service and envoy proxy(Istio)

### DIFF
--- a/hce/Chart.yaml
+++ b/hce/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.8.0"
 description: A Helm chart to install Harness Chaos Enterprise
 name: hce
-version: 2.8.1
+version: 2.8.2
 kubeVersion: ">=1.16.0-0"
 home: https://harness.io
 sources:

--- a/hce/README.md
+++ b/hce/README.md
@@ -1,6 +1,6 @@
 # hce
 
-![Version: 2.8.1](https://img.shields.io/badge/Version-2.8.1-informational?style=flat-square) ![AppVersion: 2.8.0](https://img.shields.io/badge/AppVersion-2.8.0-informational?style=flat-square)
+![Version: 2.8.2](https://img.shields.io/badge/Version-2.8.2-informational?style=flat-square) ![AppVersion: 2.8.0](https://img.shields.io/badge/AppVersion-2.8.0-informational?style=flat-square)
 
 A Helm chart to install Harness Chaos Enterprise
 
@@ -33,7 +33,7 @@ Kubernetes: `>=1.16.0-0`
 | adminConfig.JWTSecret | string | `"litmus-portal@123"` |  |
 | adminConfig.VERSION | string | `"2.8.0"` |  |
 | customLabels | object | `{}` | Additional labels |
-| image.imagePullSecrets[0].name | string | `"regcred"` |  |
+| image.imagePullSecrets | list | `[]` |  |
 | image.imageRegistryName | string | `"chaosnative"` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
@@ -133,6 +133,7 @@ Kubernetes: `>=1.16.0-0`
 | portal.frontend.virtualService.enabled | bool | `false` |  |
 | portal.frontend.virtualService.gateways | list | `[]` |  |
 | portal.frontend.virtualService.hosts | list | `[]` |  |
+| portal.frontend.virtualService.pathPrefixEnabled | bool | `false` |  |
 | portal.graphqlServer.affinity | object | `{}` |  |
 | portal.graphqlServer.customLabels | object | `{}` |  |
 | portal.graphqlServer.genericEnv.AGENT_DEPLOYMENTS | string | `"[\"app=chaos-exporter\", \"name=chaos-operator\", \"app=event-tracker\", \"app=workflow-controller\"]"` |  |
@@ -207,8 +208,8 @@ Kubernetes: `>=1.16.0-0`
 | portalScope | string | `"cluster"` |  |
 | upgradeAgent.affinity | object | `{}` |  |
 | upgradeAgent.controlPlane.image.pullPolicy | string | `"Always"` |  |
-| upgradeAgent.controlPlane.image.repository | string | `"upgrade-agent-cp"` |  |
-| upgradeAgent.controlPlane.image.tag | string | `"ci"` |  |
+| upgradeAgent.controlPlane.image.repository | string | `"hce-upgrade-agent-cp"` |  |
+| upgradeAgent.controlPlane.image.tag | string | `"2.8.0"` |  |
 | upgradeAgent.nodeSelector | object | `{}` |  |
 | upgradeAgent.tolerations | list | `[]` |  |
 

--- a/hce/templates/docker-secret.yaml
+++ b/hce/templates/docker-secret.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-data:
-  .dockerconfigjson: ewoJImF1dGhzIjogewoJCSJodHRwczovL2luZGV4LmRvY2tlci5pby92MS8iOiB7CgkJCSJhdXRoIjogIlkyNWhkR2wyWlhKdk9tTnVZWFJwZG1WeWIwQXhOalU0IgoJCX0KCX0KfQo=
-kind: Secret
-metadata:
-  name: regcred
-  namespace: {{ .Release.Namespace }}
-type: kubernetes.io/dockerconfigjson

--- a/hce/templates/frontend-vs.yaml
+++ b/hce/templates/frontend-vs.yaml
@@ -18,9 +18,18 @@ spec:
     {{- toYaml . | nindent 4 }}
 {{- end }}
   http:
-    - route:
-      - destination:
-          host: litmusportal-frontend-service
-          port:
-            number: {{ .Values.portal.frontend.service.port }}
+{{- if .Values.portal.frontend.virtualService.pathPrefixEnabled }}
+  - match:
+    - uri:
+        prefix: /litmuschaos
+    rewrite:
+      uri: "/"
+    route:
+{{- else }}
+  - route:
+{{- end }}
+    - destination:
+        host: {{ include "hce.fullname" . }}-frontend-service
+        port:
+          number: {{ .Values.portal.frontend.service.port }}
 {{- end -}}

--- a/hce/templates/hce-configs.yaml
+++ b/hce/templates/hce-configs.yaml
@@ -26,12 +26,17 @@ metadata:
     app.kubernetes.io/component: {{ include "hce.name" . }}-admin-config
 data:
   default.conf: |
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
     server {
         listen       8080;
         server_name  localhost;
         #charset koi8-r;
         #access_log  /var/log/nginx/host.access.log  main;
         location / {
+            proxy_http_version 1.1;
             root   /usr/share/nginx/html;
             index  index.html index.htm;
             try_files $uri /index.html;
@@ -50,6 +55,7 @@ data:
         #    deny  all;
         #}
         location /auth/ {
+            proxy_http_version 1.1;
             proxy_set_header   Host                 $host;
             proxy_set_header   X-Real-IP            $remote_addr;
             proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
@@ -57,6 +63,7 @@ data:
             proxy_pass "http://{{ include "hce.fullname" . }}-auth-server-service:9003/";
         }
         location /api/ {
+            proxy_http_version 1.1;
             proxy_set_header   Host                 $host;
             proxy_set_header   X-Real-IP            $remote_addr;
             proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
@@ -64,6 +71,7 @@ data:
             proxy_pass "http://{{ include "hce.fullname" . }}-server-service:9002/";
         }
         location /license/ {
+            proxy_http_version 1.1;
             proxy_set_header   Host                 $host;
             proxy_set_header   X-Real-IP            $remote_addr;
             proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
@@ -71,8 +79,9 @@ data:
             proxy_pass "http://license-service/";
         }
         location /ws/ {
-            proxy_set_header   Upgrade              $http_upgrade;
-            proxy_set_header   Connection           "Upgrade";
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
             proxy_set_header   Host                 $host;
             proxy_set_header   X-Real-IP            $remote_addr;
             proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;

--- a/hce/templates/ingress.yaml
+++ b/hce/templates/ingress.yaml
@@ -10,7 +10,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ .Values.ingress.name }}
-  namespace: { { .Release.Namespace } }
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: {{ include "hce.name" . }}-frontend
     {{- include "hce.labels" . | nindent 4 }}

--- a/hce/values.yaml
+++ b/hce/values.yaml
@@ -22,8 +22,7 @@ adminConfig:
 image:
   imageRegistryName: chaosnative
   # Optional pod imagePullSecrets
-  # imagePullSecrets:
-  #   - name: regcred
+  imagePullSecrets: []
 
 ingress:
   enabled: false

--- a/hce/values.yaml
+++ b/hce/values.yaml
@@ -22,8 +22,8 @@ adminConfig:
 image:
   imageRegistryName: chaosnative
   # Optional pod imagePullSecrets
-  imagePullSecrets:
-    - name: regcred
+  # imagePullSecrets:
+  #   - name: regcred
 
 ingress:
   enabled: false
@@ -32,7 +32,7 @@ ingress:
     {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  # nginx.ingress.kubernetes.io/rewrite-target: /$1
+    # nginx.ingress.kubernetes.io/rewrite-target: /$1
 
   host:
     # -- This is ingress hostname (ex: my-domain.com)
@@ -49,8 +49,8 @@ ingress:
 upgradeAgent:
   controlPlane:
     image:
-      repository: upgrade-agent-cp
-      tag: "ci"
+      repository: hce-upgrade-agent-cp
+      tag: "2.8.0"
       pullPolicy: "Always"
   nodeSelector: {}
   tolerations: []
@@ -109,6 +109,7 @@ portal:
       enabled: false
       hosts: []
       gateways: []
+      pathPrefixEnabled: false
     nodeSelector: {}
     tolerations: []
     affinity: {}

--- a/k8s-manifests/ci/hce-cluster-scope.yaml
+++ b/k8s-manifests/ci/hce-cluster-scope.yaml
@@ -446,6 +446,10 @@ metadata:
   namespace: litmus
 data:
   default.conf: |
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
     server {
         listen       8080;
         server_name  localhost;
@@ -453,6 +457,7 @@ data:
         #access_log  /var/log/nginx/host.access.log  main;
 
         location / {
+            proxy_http_version 1.1;
             root   /usr/share/nginx/html;
             index  index.html index.htm;
             try_files $uri /index.html;
@@ -475,6 +480,7 @@ data:
         #}
 
         location /auth/ {
+            proxy_http_version 1.1;
             proxy_set_header   Host                 $host;
             proxy_set_header   X-Real-IP            $remote_addr;
             proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
@@ -483,6 +489,7 @@ data:
         }
 
         location /api/ {
+            proxy_http_version 1.1;
             proxy_set_header   Host                 $host;
             proxy_set_header   X-Real-IP            $remote_addr;
             proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
@@ -491,6 +498,7 @@ data:
         }
 
         location /license/ {
+            proxy_http_version 1.1;
             proxy_set_header   Host                 $host;
             proxy_set_header   X-Real-IP            $remote_addr;
             proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
@@ -499,8 +507,9 @@ data:
         }
 
         location /ws/ {
-            proxy_set_header   Upgrade              $http_upgrade;
-            proxy_set_header   Connection           "Upgrade";
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
             proxy_set_header   Host                 $host;
             proxy_set_header   X-Real-IP            $remote_addr;
             proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;

--- a/k8s-manifests/ci/hce-namespace.yaml
+++ b/k8s-manifests/ci/hce-namespace.yaml
@@ -424,6 +424,10 @@ metadata:
   name: litmusportal-frontend-nginx-configuration
 data:
   default.conf: |
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
     server {
         listen       8080;
         server_name  localhost;
@@ -431,6 +435,7 @@ data:
         #access_log  /var/log/nginx/host.access.log  main;
 
         location / {
+            proxy_http_version 1.1;
             root   /usr/share/nginx/html;
             index  index.html index.htm;
             try_files $uri /index.html;
@@ -453,6 +458,7 @@ data:
         #}
 
         location /auth/ {
+            proxy_http_version 1.1;
             proxy_set_header   Host                 $host;
             proxy_set_header   X-Real-IP            $remote_addr;
             proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
@@ -461,6 +467,7 @@ data:
         }
 
         location /api/ {
+            proxy_http_version 1.1;
             proxy_set_header   Host                 $host;
             proxy_set_header   X-Real-IP            $remote_addr;
             proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
@@ -469,6 +476,7 @@ data:
         }
 
         location /license/ {
+            proxy_http_version 1.1;
             proxy_set_header   Host                 $host;
             proxy_set_header   X-Real-IP            $remote_addr;
             proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
@@ -477,8 +485,9 @@ data:
         }
 
         location /ws/ {
-            proxy_set_header   Upgrade              $http_upgrade;
-            proxy_set_header   Connection           "Upgrade";
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
             proxy_set_header   Host                 $host;
             proxy_set_header   X-Real-IP            $remote_addr;
             proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;


### PR DESCRIPTION
**This PR will -**

- **Remove `docker-secret.yml`, as all images have been made public.** (Not needed, as users will create there own imagePullSecret, which was getting overridden by docker-secret.yml in previous cases)

- Add support for prefix in virtual-service for istio
- Fixes the hardcoded name of frontend-service in virtual-service
- Fixes namespace in Ingress
- Adds Support for envoy proxy through frontend-nginx-config.
- Update manifest also with nginx.conf changes.

**Above changes have been tested with Ingress as well as Virtual service, both are working fine with / & /litmuschaos paths.**